### PR TITLE
Translate Ruby 3.4.0 preview1 Released(ja)

### DIFF
--- a/ja/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
+++ b/ja/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
@@ -10,7 +10,7 @@ lang: ja
 {% assign release = site.data.releases | where: "version", "3.4.0-preview1" | first %}
 Ruby {{ release.version }}がリリースされました。
 
-## 言語の変更
+## 言語機能の変更
 
 * `frozen_string_literal`のコメントがないファイルで文字列リテラルが凍結されたように振る舞うようになりました。
   文字列リテラルが破壊的に変更された場合、非推奨の警告が表示されます。
@@ -40,7 +40,7 @@ Ruby {{ release.version }}がリリースされました。
 
 
 
-## 互換性の問題
+## 互換性に関する変更
 
 注：バグフィックスは掲載していません。
 
@@ -60,7 +60,7 @@ Ruby {{ release.version }}がリリースされました。
   ```
 
 
-## CのAPI更新
+## C API更新
 
 * `rb_newobj`と`rb_newobj_of` (および対応するマクロ `RB_NEWOBJ`、`RB_NEWOBJ_OF`、`NEWOBJ`、`NEWOBJ_OF`)が削除されました。 [[Feature #20265]]
 * 廃止された関数`rb_gc_force_recycle`が削除されました。 [[Feature #18290]]
@@ -83,7 +83,7 @@ Ruby {{ release.version }}がリリースされました。
 これらの変更により、Ruby 3.3.0から[{{ release.stats.files_changed }} ファイルが変更され、{{ release.stats.insertions }} 行が追加され、 {{ release.stats.deletions }} 行が削除されました！](https://github.com/ruby/ruby/compare/v3_3_0...{{ release.tag }}#file_bucket)
 
 
-## Download
+## ダウンロード
 
 * <{{ release.url.gz }}>
 
@@ -108,8 +108,7 @@ Ruby {{ release.version }}がリリースされました。
 
 ## Rubyとは
 
-Rubyは1993年にMatz（まつもとゆきひろ）によって開発され、現在はオープンソースとして開発されています。
-オープンソースとして開発されており、複数のプラットフォームで動作し、特にウェブ開発において世界中で利用されています。
+Rubyはまつもとゆきひろ (Matz) によって1993年に開発が始められ、今もオープンソースソフトウェアとして開発が続けられています。Rubyは様々なプラットフォームで動き、世界中で、特にWebアプリケーション開発のために使われています。
 
 [Feature #13557]: https://bugs.ruby-lang.org/issues/13557
 [Feature #15554]: https://bugs.ruby-lang.org/issues/15554

--- a/ja/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
+++ b/ja/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
@@ -1,0 +1,127 @@
+---
+layout: news_post
+title: "Ruby 3.4.0 preview1 リリース"
+author: "naruse"
+translator: "01hayakawa"
+date: 2024-05-16 00:00:00 +0000
+lang: ja
+---
+
+{% assign release = site.data.releases | where: "version", "3.4.0-preview1" | first %}
+Ruby {{ release.version }}がリリースされました。
+
+## 言語の変更
+
+* `frozen_string_literal`のコメントがないファイルで文字列リテラルが凍結されたように振る舞うようになりました。
+  文字列リテラルが破壊的に変更された場合、非推奨の警告が表示されます。
+  この警告は `-W:deprecated` または `Warning[:deprecated] = true` で有効にすることができます。
+  コマンドライン引数で`--disable-frozen-string-literal` を指定してRubyを実行すると、この変更を無効にできます。 [[Feature #20205]]
+
+* `it`がブロックパラメータを参照するために追加されました。 [[Feature #18980]]
+
+* メソッド呼び出し時のnilのキーワードスプラットが使えるようになりました。
+  `**nil`は`**{}`と同様に扱われ、キーワードは渡されず、変換メソッドも呼び出されません。 [[Bug #20064]]
+
+* インデックスにブロックを渡せなくなりました。 [[Bug #19918]]
+
+* インデックスにキーワード引数が使えなくなりました。 [[Bug #20218]]
+
+## コアクラスの更新
+注：特に重要なクラスアップデートのみを掲載しています。
+
+* Exception
+
+  * Exception#set_backtraceが`Thread::Backtrace::Location`の配列を受け付けるようになりました。
+    `Kernel#raise`と`Thread#raise`、`Fiber#raise`も同様に新しいフォーマットを受け付けます。[[Feature #13557]]
+
+* Range
+
+  * rangeがイテラブルでない場合、`Range#size`がTypeErrorを発生させるようになりました。[[Misc #18984]]
+
+
+
+## 互換性の問題
+
+注：バグフィックスは掲載していません。
+
+* エラーメッセージとバックトレースの表示が変更されました。
+  * 冒頭の引用符にはバッククォートの代わりにシングルクォートを使用します。 [[Feature #16495]]
+  * メソッド名の前にクラス名を表示します(クラスが永続的な名前を持つ場合のみ)。 [[Feature #19117]]
+  * `Kernel#caller`、`Thread::Backtrace::Location`のメソッドなどがそれに応じて変更されました。
+
+  ```
+  Old:
+  test.rb:1:in `foo': undefined method `time' for an instance of Integer
+          from test.rb:2:in `<main>'
+
+  New:
+  test.rb:1:in 'Object#foo': undefined method 'time' for an instance of Integer
+          from test.rb:2:in `<main>'
+  ```
+
+
+## CのAPI更新
+
+* `rb_newobj`と`rb_newobj_of` (および対応するマクロ `RB_NEWOBJ`、`RB_NEWOBJ_OF`、`NEWOBJ`、`NEWOBJ_OF`)が削除されました。 [[Feature #20265]]
+* 廃止された関数`rb_gc_force_recycle`が削除されました。 [[Feature #18290]]
+
+## 実装の改善
+
+* `Array#each`がRubyで書き直され、パフォーマンスが改善されました。 [[Feature #20182]].
+
+## その他の変更
+
+* 渡されたブロックを使用しないメソッドにブロックを渡すと、verboseモード (`-w`) で警告が表示されるようになりました。 [[Feature #15554]]
+
+* `String.freeze`や`Integer#+`のようなインタプリタやJITによって特別に最適化されたコアメソッドを再定義すると、パフォーマンスクラスの警告（`-W:performance`または`Warning[:performance] = true`）が出るようになりました。　[[Feature #20429]]
+
+デフォルトのgemsやバンドルされているgemの詳細については、[Logger](https://github.com/ruby/logger/releases)などのGitHubのリリースやchangelogを参照してください。
+
+詳細は[NEWS](https://github.com/ruby/ruby/blob/{{ release.tag }}/NEWS.md)
+か[commit logs](https://github.com/ruby/ruby/compare/v3_3_0...{{ release.tag }})を参照してください。
+
+これらの変更により、Ruby 3.3.0から[{{ release.stats.files_changed }} ファイルが変更され、{{ release.stats.insertions }} 行が追加され、 {{ release.stats.deletions }} 行が削除されました！](https://github.com/ruby/ruby/compare/v3_3_0...{{ release.tag }}#file_bucket)
+
+
+## Download
+
+* <{{ release.url.gz }}>
+
+      SIZE: {{ release.size.gz }}
+      SHA1: {{ release.sha1.gz }}
+      SHA256: {{ release.sha256.gz }}
+      SHA512: {{ release.sha512.gz }}
+
+* <{{ release.url.xz }}>
+
+      SIZE: {{ release.size.xz }}
+      SHA1: {{ release.sha1.xz }}
+      SHA256: {{ release.sha256.xz }}
+      SHA512: {{ release.sha512.xz }}
+
+* <{{ release.url.zip }}>
+
+      SIZE: {{ release.size.zip }}
+      SHA1: {{ release.sha1.zip }}
+      SHA256: {{ release.sha256.zip }}
+      SHA512: {{ release.sha512.zip }}
+
+## Rubyとは
+
+Rubyは1993年にMatz（まつもとゆきひろ）によって開発され、現在はオープンソースとして開発されています。
+オープンソースとして開発されており、複数のプラットフォームで動作し、特にウェブ開発において世界中で利用されています。
+
+[Feature #13557]: https://bugs.ruby-lang.org/issues/13557
+[Feature #15554]: https://bugs.ruby-lang.org/issues/15554
+[Feature #16495]: https://bugs.ruby-lang.org/issues/16495
+[Feature #18290]: https://bugs.ruby-lang.org/issues/18290
+[Feature #18980]: https://bugs.ruby-lang.org/issues/18980
+[Misc #18984]:    https://bugs.ruby-lang.org/issues/18984
+[Feature #19117]: https://bugs.ruby-lang.org/issues/19117
+[Bug #19918]:     https://bugs.ruby-lang.org/issues/19918
+[Bug #20064]:     https://bugs.ruby-lang.org/issues/20064
+[Feature #20182]: https://bugs.ruby-lang.org/issues/20182
+[Feature #20205]: https://bugs.ruby-lang.org/issues/20205
+[Bug #20218]:     https://bugs.ruby-lang.org/issues/20218
+[Feature #20265]: https://bugs.ruby-lang.org/issues/20265
+[Feature #20429]: https://bugs.ruby-lang.org/issues/20429

--- a/ja/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
+++ b/ja/news/_posts/2024-05-16-ruby-3-4-0-preview1-released.md
@@ -36,7 +36,7 @@ Ruby {{ release.version }}がリリースされました。
 
 * Range
 
-  * rangeがイテラブルでない場合、`Range#size`がTypeErrorを発生させるようになりました。[[Misc #18984]]
+  * rangeが列挙可能でない場合、`Range#size`がTypeErrorを発生させるようになりました。[[Misc #18984]]
 
 
 
@@ -63,7 +63,7 @@ Ruby {{ release.version }}がリリースされました。
 ## C API更新
 
 * `rb_newobj`と`rb_newobj_of` (および対応するマクロ `RB_NEWOBJ`、`RB_NEWOBJ_OF`、`NEWOBJ`、`NEWOBJ_OF`)が削除されました。 [[Feature #20265]]
-* 廃止された関数`rb_gc_force_recycle`が削除されました。 [[Feature #18290]]
+* 廃止予定だった関数`rb_gc_force_recycle`が削除されました。 [[Feature #18290]]
 
 ## 実装の改善
 
@@ -75,7 +75,7 @@ Ruby {{ release.version }}がリリースされました。
 
 * `String.freeze`や`Integer#+`のようなインタプリタやJITによって特別に最適化されたコアメソッドを再定義すると、パフォーマンスクラスの警告（`-W:performance`または`Warning[:performance] = true`）が出るようになりました。　[[Feature #20429]]
 
-デフォルトのgemsやバンドルされているgemの詳細については、[Logger](https://github.com/ruby/logger/releases)などのGitHubのリリースやchangelogを参照してください。
+default gemやbundled gemの詳細については、[Logger](https://github.com/ruby/logger/releases)などのGitHubのリリースやchangelogを参照してください。
 
 詳細は[NEWS](https://github.com/ruby/ruby/blob/{{ release.tag }}/NEWS.md)
 か[commit logs](https://github.com/ruby/ruby/compare/v3_3_0...{{ release.tag }})を参照してください。
@@ -106,7 +106,7 @@ Ruby {{ release.version }}がリリースされました。
       SHA256: {{ release.sha256.zip }}
       SHA512: {{ release.sha512.zip }}
 
-## Rubyとは
+## Ruby とは
 
 Rubyはまつもとゆきひろ (Matz) によって1993年に開発が始められ、今もオープンソースソフトウェアとして開発が続けられています。Rubyは様々なプラットフォームで動き、世界中で、特にWebアプリケーション開発のために使われています。
 


### PR DESCRIPTION
## 概要
[Ruby 3.4.0 preview1 Released](https://www.ruby-lang.org/en/news/2024/05/16/ruby-3-4-0-preview1-released/)を日本語訳しました。

## 確認いただきたい点
* 言語の変更の`frozen_string_literal`の部分について、原文だと『String literals in files without a frozen_string_literal comment now behave as if they were frozen. 』とありますが、実際の挙動を確認したところ文字列リテラルがfreezeされたように振る舞う(FrozenErrorが出る)わけではなく、警告が出るという挙動でした。これは3.4.0から導入されたチルド文字列という状態のようです。[参考](https://zenn.dev/mamayukawaii/articles/20240404003435#ruby-3.4-%E3%81%A7%E3%81%AA%E3%81%AB%E3%81%8C%E5%A4%89%E3%82%8F%E3%82%8B%E3%81%AE%EF%BC%9F) 翻訳としては原文と齟齬が出てしまうので、ひとまず原文を優先しています。
* その他、日本語としておかしい部分がないか。